### PR TITLE
Update link to OpenAIChatGptModels

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ ChatGPT can be used with different models for chat completion, both on OpenAI an
 
 ##### OpenAI
 
-Currently available models are: _gpt-3.5-turbo_, _gpt-3.5-turbo-16k_, _gpt-4_ and _gpt-4-32k_. They have fixed names, available in the [OpenAIChatGptModels.cs file](https://github.com/marcominerva/ChatGptNet/blob/master/src/ChatGptNet/Models/ChatGptModels.cs).
+Currently available models are: _gpt-3.5-turbo_, _gpt-3.5-turbo-16k_, _gpt-4_ and _gpt-4-32k_. They have fixed names, available in the [OpenAIChatGptModels.cs file](https://github.com/marcominerva/ChatGptNet/blob/master/src/ChatGptNet/Models/OpenAIChatGptModels.cs).
 
 ##### Azure OpenAI Service
 


### PR DESCRIPTION
Fix to link for OpenAI ChatGPT Models. Prior link went to 404 page.