### PR TITLE
Fix grammar in comment for MaxCompletionTokens property

### DIFF
--- a/samples/ChatGptApi/appsettings.json
+++ b/samples/ChatGptApi/appsettings.json
@@ -17,7 +17,7 @@
         //    "Temperature": 0.8,
         //    "TopP": 1,
         //    "MaxTokens": 500,
-        //    "MaxCompletionTokens": null,  // o1 series models supports this property instead of MaxTokens
+        //    "MaxCompletionTokens": null,  // o1 series models support this property instead of MaxTokens
         //    "PresencePenalty": 0,
         //    "FrequencyPenalty": 0,
         //    "ResponseFormat": { "Type": "text" }, // Allowed values for Type: text (default) or json_object


### PR DESCRIPTION
Corrected the grammar in a comment from "supports" to "support" for the o1 series models in the configuration file.